### PR TITLE
fix: add valid link to page /guide/tutorials/working-with-secrets

### DIFF
--- a/docs/v1/guide/tutorials/understand-the-workflow.md
+++ b/docs/v1/guide/tutorials/understand-the-workflow.md
@@ -112,7 +112,7 @@ Kubricate includes a modular way to manage secrets:
 * **Providers** map those secrets into Kubernetes formats (e.g. `Opaque`, `DockerConfig`, `EnvFrom`)
 * **SecretManager** coordinates all of this.
 
-You’ll explore this in `Working with Secrets`.
+You’ll explore this in [**Working with Secrets**](./working-with-secrets).
 
 ## Where to Go Next
 

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,3 @@
+[tools]
+node = "22"
+"npm:pnpm" = "10.5.2"


### PR DESCRIPTION
previously it was text in inline code-block 
<img width="1099" height="646" alt="image" src="https://github.com/user-attachments/assets/54d14cca-6e61-4ccc-ba8d-bf9cdaf94a63" />

I only change it 
<img width="1143" height="546" alt="image" src="https://github.com/user-attachments/assets/8b92da87-01ab-4213-b324-9ae20269bdd3" />

for file `mise.toml`
I use mise to manage my Node version and global packages. It shows the Node version and pnpm version explicitly, so if you don't use mise, it won't affect your project environment.